### PR TITLE
Relax install_requires restriction for webassets

### DIFF
--- a/django_assets/pytest_plugin.py
+++ b/django_assets/pytest_plugin.py
@@ -3,5 +3,4 @@ import django_assets.env
 
 @pytest.fixture(autouse=True)
 def set_django_assets_env():
-    print("Set django assets environment")
     django_assets.env.get_env() # initialise django-assets settings

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     platforms='any',
     install_requires=[
         'Django>=1.1',
-        'webassets==%s' % webassets_version
+        'webassets>=%s' % webassets_version
         ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
pytest does not like mismatched deps:

pkg_resources.VersionConflict: (webassets 0.11.dev (/Users/prophet/.envs/mybook/src/webassets/src), Requirement.parse('webassets==0.10'))
